### PR TITLE
Update old code

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -52,7 +52,11 @@ function getUserId(event) {
   // Create a new user ID if there isn't one yet
   // The user ID is a hash of the IP and the current timestamp
   const msg = event.requestContext.http.sourceIp + new Date().getTime();
-  return crypto.createHash('sha1').update(msg).digest('base64').substr(0, 27);
+  return crypto
+    .createHash('sha1')
+    .update(msg)
+    .digest('base64')
+    .substring(0, 27);
 }
 
 function getSessionId(event, userId) {
@@ -72,7 +76,11 @@ function getSessionId(event, userId) {
     new Date().getTime(),
     event.requestContext.http.sourceIp,
   ].join('');
-  return crypto.createHash('sha1').update(msg).digest('base64').substr(0, 27);
+  return crypto
+    .createHash('sha1')
+    .update(msg)
+    .digest('base64')
+    .substring(0, 27);
 }
 
 function bakeCookie(cookieName, cookieValue, maxAge) {


### PR DESCRIPTION
A couple very small code changes to fix deprecation warnings:

- Don't call `new Hash` directly
- Don't use `substr()`